### PR TITLE
Add focusin/focusout events

### DIFF
--- a/simulate.js
+++ b/simulate.js
@@ -77,6 +77,8 @@ var events = [
     'click',
     'focus',
     'blur',
+    'focusin',
+    'focusout',
     'dblclick',
     'input',
     'change',


### PR DESCRIPTION
Hi, Toby.
I'm using your library for testing purposes, but I've found there're no corresponding methods for focusin/focusout events.